### PR TITLE
Fixed setup.py

### DIFF
--- a/pyprosail.egg-info/.gitignore
+++ b/pyprosail.egg-info/.gitignore
@@ -1,0 +1,4 @@
+/PKG-INFO
+/SOURCES.txt
+/dependency_links.txt
+/top_level.txt

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 
+import setuptools
+
 from numpy.distutils.core import setup, Extension
 from numpy.distutils.misc_util import Configuration
 


### PR DESCRIPTION
An important of `setuptools` was missing causing `python setup.py bdist_wheel` to fail. This has been fixed by doing some "magic" as suggested [here](https://stackoverflow.com/questions/55352409/python-setuptools-compile-fortran-code-and-make-an-entry-points).